### PR TITLE
Add Text as a source field to allow Bulk-add to work with MCD plugin notes

### DIFF
--- a/japanese/reading.py
+++ b/japanese/reading.py
@@ -10,7 +10,7 @@ import sys, os, platform, re, subprocess
 from anki.utils import stripHTML, isWin, isMac
 from anki.hooks import addHook
 
-srcFields = ['Expression']
+srcFields = ['Expression', 'Text']
 dstFields = ['Reading']
 
 kakasiArgs = ["-isjis", "-osjis", "-u", "-JH", "-KH"]


### PR DESCRIPTION
Occasionally people add a big batch of MCD cards without realizing they didn't install the Japanese Support plugin first.  This change makes Bulk-add Readings work with the default Note type in my plugin.
