### PR TITLE
Moved notetype restrictions, users can now update them globally from one place

### DIFF
--- a/japanese/bulkreading.py
+++ b/japanese/bulkreading.py
@@ -9,6 +9,7 @@ from PyQt4.QtCore import *
 from PyQt4.QtGui import *
 from anki.hooks import addHook
 from japanese.reading import mecab, srcFields, dstFields
+from notetypes import isActiveNoteType
 from aqt import mw
 
 # Bulk updates
@@ -20,20 +21,24 @@ def regenerateReadings(nids):
     mw.progress.start()
     for nid in nids:
         note = mw.col.getNote(nid)
-        if "japanese" not in note.model()['name'].lower():
+        # Amend notetypes.py to add your note types
+        _noteName = note.model()['name'].lower()
+        if not isActiveNoteType(_noteName):
             continue
+
         src = None
-        for fld in srcFields:
-            if fld in note:
-                src = fld
+        for field in srcFields:
+            if field in note:
+                src = field
                 break
         if not src:
             # no src field
             continue
+        # dst is the destination field for the Readings
         dst = None
-        for fld in dstFields:
-            if fld in note:
-                dst = fld
+        for field in dstFields:
+            if field in note:
+                dst = field
                 break
         if not dst:
             # no dst field

--- a/japanese/notetypes.py
+++ b/japanese/notetypes.py
@@ -1,0 +1,37 @@
+"""
+-*- coding: utf-8 -*-
+Author: RawToast
+License: GNU GPL, version 3 or later; http://www.gnu.org/copyleft/gpl.html
+
+Configure settings for the note types and source fields for the Japanese Support plugin here
+"""
+
+# If sets to True the plugin will work for ALL note types.
+EFFECT_ALL_NOTES = False
+
+# The note type(s) that the plugin will act upon. This is case insensitive. Add your own note types here, for
+# example: NOTE_TYPES = ["japanese", "subs"]
+# If EFFECT_ALL_NOTES is True, this has no effect
+NOTE_TYPES = ["japanese"]
+
+# Looks for Kanji in these fields. Replaces source fields in stats.py line 15
+SOURCE_FIELDS = ["Expression", "Kanji"]
+
+
+def isActiveNoteType(noteName):
+    """
+    Should bulk readings be added to the note type chosen?
+    :param note: The selected card's note type
+    :return: True if we should add readings to the notes
+    """
+    _result = False
+    if not EFFECT_ALL_NOTES:
+        for _note in NOTE_TYPES:
+            if noteName in _note:
+                _result = True
+    else:
+        _result = True
+
+    return _result
+
+

--- a/japanese/stats.py
+++ b/japanese/stats.py
@@ -10,9 +10,12 @@ from aqt import mw
 from aqt.webview import AnkiWebView
 from aqt.qt import *
 from aqt.utils import restoreGeom, saveGeom
+from notetypes import SOURCE_FIELDS, isActiveNoteType
+
 
 # look for kanji in these fields
-srcFields = ["Expression", "Kanji"]
+# Look at notetypes.py to changes this setting
+srcFields = SOURCE_FIELDS
 
 def isKanji(unichar):
     try:
@@ -56,8 +59,10 @@ class KanjiStats(object):
         self.kanjiSets = [set([]) for g in self.kanjiGrades]
         chars = set()
         for m in self.col.models.all():
-            if "japanese" not in m['name'].lower():
+            _noteName = m['name'].lower()
+            if not isActiveNoteType(_noteName):
                 continue
+
             idxs = []
             for c, name in enumerate(self.col.models.fieldNames(m)):
                 for f in srcFields:


### PR DESCRIPTION
Note type and source field magic strings moved to simple notetypes.py file for user configuration. Added user config option to ignore notetypes.

This fixes the common complaint from users that the plugin only supports notes named 'japanese'
