### PR TITLE
Fixed error in note type check ("japanese")

### DIFF
--- a/japanese/notetypes.py
+++ b/japanese/notetypes.py
@@ -34,7 +34,7 @@ def isActiveNoteType(noteName):
     _result = False
     if not EFFECT_ALL_NOTES:
         for _note in NOTE_TYPES:
-            if noteName in _note:
+            if _note in noteName:
                 _result = True
     else:
         _result = True


### PR DESCRIPTION
The code now searches for a matching word in the noteName, not the
reverse.
