### PR TITLE
Keep AddCards, EditCurrent, and Browser on top

### DIFF
--- a/alwaysontop.py
+++ b/alwaysontop.py
@@ -1,14 +1,40 @@
 # -*- coding: utf-8 -*-
 # Copyright: Damien Elmes <anki@ichi2.net>
+#            Glutanimate <github.com/glutanimate>
 # License: GNU GPL, version 3 or later; http://www.gnu.org/copyleft/gpl.html
 #
 # This plugin keeps Anki on top of other windows.
 
-from ankiqt import mw
-from PyQt4.QtCore import *
-from PyQt4.QtGui import *
+from anki.hooks import wrap
 
-mw.setWindowFlags(Qt.WindowStaysOnTopHint)
-mw.show()
+from aqt import dialogs
+from aqt import mw, addcards, editcurrent, browser
+from aqt.qt import *
 
-mw.registerPlugin("Always On Top", 9)
+def alwaysOnTop():
+    mw._onTop = not mw._onTop
+    windows = [mw]
+    for dclass, instance in dialogs._dialogs.values():
+        if instance:
+            windows.append(instance)
+    for window in windows:
+        windowFlags = window.windowFlags()
+        windowFlags ^= Qt.WindowStaysOnTopHint
+        window.setWindowFlags(windowFlags)
+        window.show()
+
+def onWindowInit(self, *args, **kwargs):
+    if mw._onTop:
+        windowFlags = self.windowFlags() | Qt.WindowStaysOnTopHint
+        self.setWindowFlags(windowFlags)
+        self.show()
+    
+mw._onTop = False
+action = QAction("Always on top", mw)
+action.setCheckable(True)
+mw.connect(action, SIGNAL("triggered()"), alwaysOnTop)
+mw.form.menuTools.addAction(action)
+
+addcards.AddCards.__init__ = wrap(addcards.AddCards.__init__, onWindowInit, "after")
+editcurrent.EditCurrent.__init__ = wrap(editcurrent.EditCurrent.__init__, onWindowInit, "after")
+browser.Browser.__init__ = wrap(browser.Browser.__init__, onWindowInit, "after")


### PR DESCRIPTION
With this commit the state for the child windows mentioned above can now also be controlled through the "on-top" toggle.