### PR TITLE
Add support for changing order of reviews to v2 scheduler

### DIFF
--- a/revorder/__init__.py
+++ b/revorder/__init__.py
@@ -17,6 +17,11 @@ order = "ivl desc"
 
 from anki.sched import Scheduler
 
+import random
+import anki
+from anki.utils import ids2str
+from anki.schedv2 import Scheduler
+
 def _fillRev(self):
     if self._revQueue:
         return True
@@ -47,4 +52,39 @@ did = ? and queue = 2 and due <= ?"""
         # nothing left in the deck; move to next
         self._revDids.pop(0)
 
-Scheduler._fillRev = _fillRev
+anki.sched.Scheduler._fillRev = _fillRev
+
+def _v2_fillRev(self):
+    if self._revQueue:
+        return True
+    if not self.revCount:
+        return False
+
+    lim = min(self.queueLimit, self._currentRevLimit())
+    if lim:
+        self._revQueue = self.col.db.list("""
+select id from cards where
+did in %s and queue = 2 and due <= ?
+order by due
+limit ?""" % (ids2str(self.col.decks.active())),
+                self.today, lim)
+
+        if self._revQueue:
+            if self.col.decks.get(self.col.decks.selected(), default=False)['dyn']:
+                # dynamic decks need due order preserved
+                self._revQueue.reverse()
+            else:
+                # fixme: as soon as a card is answered, this is no longer consistent
+                r = random.Random()
+                r.seed(self.today)
+                r.shuffle(self._revQueue)
+            return True
+
+    if self.revCount:
+        # if we didn't get a card but the count is non-zero,
+        # we need to check again for any cards that were
+        # removed from the queue but not buried
+        self._resetRev()
+        return self._fillRev()
+
+anki.schedv2.Scheduler._fillRev = _v2_fillRev


### PR DESCRIPTION
This adds support for changing the order of reviews in regular decks under the v2 scheduler.  While filtered decks have improved under the v2 scheduler they lack granular control over new cards.  For example, if the user wants to learn 5 new cards from *Main::Grammar*, 10 from *Main::Vocab* and 7 from *Main::Geography* each day, this is difficult to do with filtered decks.  This add-on allows users to have granular control over both their new cards and have their reviews ordered as desired, in a single study session.