### PR TITLE
Number format fix in Kanji Stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _build
 .idea
 __pycache__
 meta.json
+.*.swp

--- a/build.py
+++ b/build.py
@@ -20,6 +20,8 @@ def build_all():
             needed.append(dir)
 
     if needed:
+        print("testing...")
+        test(needed)
         print("linting...")
         lint(needed)
         for dir in needed:
@@ -38,21 +40,31 @@ def build(dir):
     ensure_manifest(dir)
     subprocess.check_call(["7z", "a", "-tzip",
                            "-x!meta.json",
+                           "-x!tests",
                            "-bso0", # less verbose
                            out,
                            # package folder contents but not folder itself
                            "-w", os.path.join(dir, ".")])
 
+def test(dirs):
+    try:
+        run(["pytest"] + dirs)
+    except subprocess.CalledProcessError:
+        print("Ignoring failed tests for now")
+
 def lint(dirs):
-    env=os.environ.copy()
-    env["PYTHONPATH"]="../dtop"
-    subprocess.check_call([
+    run([
         "pylint",
         "-j", "0",
         "--rcfile=../dtop/.pylintrc",
         "-f", "colorized",
         "--extension-pkg-whitelist=PyQt5",
-    ] + dirs, env=env)
+    ] + dirs)
+
+def run(cmd):
+    env=os.environ.copy()
+    env["PYTHONPATH"]="../dtop"
+    subprocess.check_call(cmd, env=env)
 
 def ensure_manifest(dir):
     manifest_path = os.path.join(dir, "manifest.json")

--- a/japanese/stats.py
+++ b/japanese/stats.py
@@ -46,19 +46,14 @@ class KanjiStats(object):
     def kanjiGrade(self, unichar):
         return self._gradeHash.get(unichar, 0)
 
-    # FIXME: as it's html, the width doesn't matter
-    def kanjiCountStr(self, gradename, count, total=0, width=0):
-        d = {'count': self.rjustfig(count, width), 'gradename': gradename}
+    def kanjiCountStr(self, gradename, count, total=0):
+        d = {'count': count, 'gradename': gradename}
         if total:
-            d['total'] = self.rjustfig(total, width)
+            d['total'] = total
             d['percent'] = float(count)/total*100
             return ("%(gradename)s: %(count)s of %(total)s (%(percent)0.1f%%).") % d
         else:
             return ("%(count)s %(gradename)s kanji.") % d
-
-    def rjustfig(self, n, width):
-        n = unicode(n)
-        return n + "&nbsp;" * (width - len(n))
 
     def genKanjiSets(self):
         self.kanjiSets = [set([]) for g in self.kanjiGrades]
@@ -109,7 +104,7 @@ where c.nid = n.id and mid = ? and c.queue > 0
                "<li>%s</li>" % self.kanjiCountStr(*counts[0]))
 
         out += "</ul><p/>" + (u"Jouyou levels:") + "<p/><ul>"
-        L = ["<li>" + self.kanjiCountStr(c[0],c[1],c[2], width=3) + "</li>"
+        L = ["<li>" + self.kanjiCountStr(c[0],c[1],c[2]) + "</li>"
              for c in counts[1:8]]
         out += "".join(L)
         out += "</ul>"

--- a/japanese/tests/test_stats.py
+++ b/japanese/tests/test_stats.py
@@ -1,0 +1,22 @@
+from mock import MagicMock
+from unittest import TestCase
+
+from japanese.stats import KanjiStats
+
+
+class TestKanjiStats(TestCase):
+    def setUp(self):
+        self.col = MagicMock()
+        self.kanji_stats = KanjiStats(self.col, wholeCollection=True)
+
+    def test_kanjiCountStr(self):
+        self.assertEqual(
+            self.kanji_stats.kanjiCountStr('Grade-X', 200),
+            '200 Grade-X kanji.'
+        )
+
+    def test_kanjiCountStr_with_total(self):
+        self.assertEqual(
+            self.kanji_stats.kanjiCountStr('Grade-Y', 200, 1000),
+            'Grade-Y: 200 of 1000 (20.0%).'
+        )


### PR DESCRIPTION
In Japanese Support/Kanji Stats:
1. Fixed number format (was e.g., "New Jouyou: (193,) of (196,) (98.5%)")
2. Removed unnecessary whitespace padding for HTML.

Also added minimal unit test for the change. Depends on an importable "../dtop" (I whipped something up locally).