### PR TITLE
Configure black profile for isort

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,8 +1,3 @@
 [settings]
+profile=black
 skip=fastbar,archive,vendor
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses=True
-line_length=88
-ensure_newline_before_comments=true

--- a/code/japanese/lookup.py
+++ b/code/japanese/lookup.py
@@ -7,9 +7,8 @@
 from __future__ import annotations
 
 import re
-from urllib.parse import quote
-
 from enum import Enum
+from urllib.parse import quote
 
 from aqt import mw
 from aqt.qt import *


### PR DESCRIPTION
Use the profile rather than the equivalent custom options.

https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#isort