### PR TITLE
chore(isort): change `skip` to `extend_skip`

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
-skip=fastbar,archive,vendor
+extend_skip=fastbar,archive,vendor
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0


### PR DESCRIPTION
Otherwise we'd no longer skip `.git`, `.venv` and other default directories.

- https://pycqa.github.io/isort/docs/configuration/options#skip
- https://pycqa.github.io/isort/docs/configuration/options#extend-skip